### PR TITLE
Fixing google Colab CPU-only support.

### DIFF
--- a/gbgpu/utils/utility.py
+++ b/gbgpu/utils/utility.py
@@ -18,7 +18,7 @@ try:
     from cupy.cuda.runtime import setDevice
 
 
-except ModuleNotFoundError:
+except (ModuleNotFoundError, ImportError):
     setDevice = None
 
 


### PR DESCRIPTION
When this module is installed on a google colab CPU instance importing gpgpu.gpgpu creates an ImportError that bubbles up to user level because cuda is installed, but not in a way that lets cuda be imported. This catches the ImportError and continues as normal.