### PR TITLE
Add CI workflow to run tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,55 @@
+name: Run tests on push
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  install_and_run_tests:
+    name: Install and run non-GPU tests
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash -el {0}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-24.latest"]
+        python-version: ["3.12", ]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '${{ matrix.python-version }}'
+      - name: Install prerequisites
+        run: |
+          apt-get install libgsl0-dev
+      - name: Install package
+        run: |
+          which python
+          python --version
+          python scripts/prebuild.py
+          python -m pip install .
+      - name: Install coverage
+        run: |
+          python -m pip install coverage[toml]
+      - name: Run module tests
+        run: |
+          cd gbgpu/tests
+          coverage run --source=few -m unittest discover
+      - name: Show coverage results
+        run: |
+          coverage report -m
+      - name: Upload coverage results as artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ strategy.job-index }}
+          path: .coverage
+          retention-days: 2
+          include-hidden-files: true
+          if-no-files-found: error


### PR DESCRIPTION
This PR adds a basic CI workflow to run the unit tests.

# Overview

The workflow is really simple. We just install GBGPU, run the tests and display coverage information (this not used any further for now).

However, I had to modify the `pyproject.toml` file. to simplify installation of the build and run dependencies. 

There are a few questions left (see below).

# Details

The workflow runs:
- when pushing on `main`
- on PR toward `main`
- on demand

To install the package, I use `pip`. This works thanks to having dependencies in `pyproject.toml`.

# Questions

1. Inspired by the `README.md`, the action only runs on python 3.12. Do you want to add more versions ? Going back to python 3.10 and up to 3.13 might be worth.
2. The action only run on `ubuntu-latest`. Do you want to add more OSes ? I guess adding macOS and older versions of ubuntu is worth.
3. If we want to use a development model where the branch `dev` is used to integrate various branches, we should probably run the workflow when pushing on `dev` and on PR toward `dev`.
4. I can update `README.md` with the current installation instructions (i.e. based on `pip`).