### PR TITLE
Add CI workflow to run tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,48 @@
+name: Run unittests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  install_and_run_tests:
+    name: Install and run tests
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash -el {0}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest", ]
+        python-version: ["3.12", ]
+    steps:
+      - name: Get the code
+        uses: actions/checkout@v4
+      - name: Install python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '${{ matrix.python-version }}'
+      - name: Install prerequisites
+        run: |
+          sudo apt-get install libgsl0-dev
+      - name: Install package
+        run: |
+          which python
+          python --version
+          python scripts/prebuild.py
+          python -m pip install .
+      - name: Install coverage
+        run: |
+          python -m pip install coverage[toml]
+      - name: Run module tests & show coverage results
+        # Tests must be run in gbgpu/tests
+        run: |
+          cd gbgpu/tests
+          coverage run --source=gbgpu -m unittest discover
+          coverage report -m

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -29,8 +29,9 @@ jobs:
         with:
           python-version: '${{ matrix.python-version }}'
       - name: Install prerequisites
-        run: |
-          sudo apt-get install libgsl0-dev
+        uses: ConorMacBride/install-package@v1
+        with:
+          apt: libgsl0-dev
       - name: Install package
         run: |
           which python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,3 +31,11 @@ dependencies = [
   "h5py",
   "lisaanalysistools",
 ]
+
+[project.optional-dependencies]
+cuda11 = [
+  "cupy-cuda11x"
+]
+cuda12 = [
+  "cupy-cuda12x"
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,25 +1,33 @@
-
 [build-system]
-requires = ["setuptools", "wheel", "Cython",  "numpy", "lisaanalysistools"]
+requires = [
+  "setuptools",
+  "wheel",
+  "Cython",
+  "numpy",
+  "lisaanalysistools",
+]
 build-backend = 'setuptools.build_meta'
 
-[tool.poetry]
+[project]
 name = "gbgpu"
 version = "1.1.3"
 description = "GPU/CPU Galactic Binary Waveforms"
-license = "GPL"
-classifiers = ["Programming Language :: Python :: 3", "Operating System :: OS Independent"]
-homepage = "https://github.com/mikekatz04/GBGPU"
-authors = ["Michael L. Katz"]
+license = "GPL-3.0-or-later"
+classifiers = [
+  "Programming Language :: Python :: 3",
+  "Operating System :: OS Independent"
+]
+authors = [
+  { name = "Michael Katz", email = "mikekatz04@gmail.com" },
+]
 readme = "README.md"
 
-[tool.poetry.dependencies]
-python = "*"
-# astropy = "==5.2.1"
-# corner = "==2.2.1"
-# healpy = "==1.16.2"
-# "ligo.skymap" = "==1.0.4"
-# matplotlib = "==3.6.3"
-# pandas = "==1.5.2"
-# seaborn = "==0.12.2"
-# tables = "==3.8.0"
+requires-python = ">= 3.12"
+dependencies = [
+  "requests",
+  "numpy",
+  "scipy",
+  "matplotlib",
+  "h5py",
+  "lisaanalysistools",
+]

--- a/setup.py
+++ b/setup.py
@@ -183,7 +183,6 @@ setup(
     name="gbgpu",
     # Random metadata. there's more you can supply
     author="Michael Katz",
-    version="1.1.3",
     packages=[
         "gbgpu",
         "gbgpu.utils",


### PR DESCRIPTION
This PR adds a basic CI workflow to run the unit tests.

# Overview

The workflow is really simple. We just install GBGPU without CUDA, run the tests and display coverage information (this not used any further for now).

However, I had to modify the `pyproject.toml` file to simplify installation of the build and run dependencies. 

There are a few questions left (see below).

# Details

The workflow runs:
- when pushing on `main`
- on PR toward `main`
- on demand

If you want to have a look at it running, you can go on the fork and run it from the "Actions" tab.

To install the package, I use `pip`. This works thanks to having dependencies in `pyproject.toml`.

# Questions

1. Inspired by the `README.md`, the workflow only runs on python 3.12. Do you want to add more versions ? Going back to python 3.10 and up to 3.13 might be worth.
2. The workflow only run on `ubuntu-latest`. Do you want to add more OSes ? I guess adding macOS and older versions of ubuntu is worth.
3. If we want to use a development model where the branch `dev` is used to integrate various branches, we should probably run the workflow when pushing on `dev` and on PR toward `dev`.
4. I can update `README.md` with the current installation instructions (i.e. based on `pip`).