### PR TITLE
Remove GSL from CI

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -38,7 +38,6 @@ jobs:
         run: |
           python -m pip install coverage[toml]
       - name: Run module tests & show coverage results
-        # Tests must be run in gbgpu/tests
         run: |
           coverage run --source=gbgpu -m unittest discover
           coverage report -m


### PR DESCRIPTION
This PR updates the CI rules: as GSL is no longer needed, we don't install it.