### PR TITLE
Cuda 13x compatibility

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -99,6 +99,13 @@ jobs:
             cuda_major: 12
             cuda_minor: 4
             reqpython: '>=3.9'
+          - release: cuda13x
+            os: ubuntu-latest
+            arch: x86_64
+            kind: cuda_plugin
+            cuda_major: 13
+            cuda_minor: 4
+            reqpython: '>=3.9'
           - release: cpu
             os: ubuntu-24.04-arm
             arch: aarch64
@@ -117,6 +124,13 @@ jobs:
             target: manylinux
             kind: cuda_plugin
             cuda_major: 12
+            cuda_minor: 6
+          - release: cuda13x
+            os: ubuntu-latest
+            arch: aarch64
+            target: manylinux
+            kind: cuda_plugin
+            cuda_major: 13
             cuda_minor: 6
           - release: cpu
             os: macos-13

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ pip install gbgpu-cuda11x
 
 # For GPU-enabled versions with CUDA 12.Y.Z
 pip install gbgpu-cuda12x
+
+# For GPU-enabled versions with CUDA 13.Y.Z
+pip install gbgpu-cuda13x
 ```
 
 To know your CUDA version, run the tool `nvidia-smi` in a terminal a check the CUDA version reported in the table header:
@@ -43,16 +46,17 @@ import gbgpu
 You may check the currently available backends:
 
 ```py3
->>> for backend in ["cpu", "cuda11x", "cuda12x", "cuda", "gpu"]:
+>>> for backend in ["cpu", "cuda11x", "cuda12x", "cuda13x, "cuda", "gpu"]:
 ...     print(f" - Backend '{backend}': {"available" if gbgpu.has_backend(backend) else "unavailable"}")
  - Backend 'cpu': available
  - Backend 'cuda11x': unavailable
  - Backend 'cuda12x': unavailable
+ - Backend 'cuda13x': unavailable
  - Backend 'cuda': unavailable
  - Backend 'gpu': unavailable
 ```
 
-Note that the `cuda` backend is an alias for either `cuda11x` or `cuda12x`. If any is available, then the `cuda` backend is available.
+Note that the `cuda` backend is an alias for either `cuda11x`, `cuda12x`, or `cuda13x`. If any is available, then the `cuda` backend is available.
 Similarly, the `gpu` backend is (for now) an alias for `cuda`.
 
 If you expected a backend to be available but it is not, run the following command to obtain an error

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,7 @@ sdist.include = [
   "src/gbgpu/git_version.py",                 #@SKIP_PLUGIN@
   "src/gbgpu_backend_cuda11x/git_version.py",
   "src/gbgpu_backend_cuda12x/git_version.py",
+  "src/gbgpu_backend_cuda13x/git_version.py",
   "tests/"
 ]
 sdist.exclude = [

--- a/src/gbgpu/cutils/__init__.py
+++ b/src/gbgpu/cutils/__init__.py
@@ -7,7 +7,7 @@ import abc
 from typing import Optional, Sequence, TypeVar, Union
 from ..utils.exceptions import *
 
-from gpubackendtools.gpubackendtools import BackendMethods, CpuBackend, Cuda11xBackend, Cuda12xBackend
+from gpubackendtools.gpubackendtools import BackendMethods, CpuBackend, Cuda11xBackend, Cuda12xBackend, Cuda13xBackend
 from gpubackendtools.exceptions import *
 
 @dataclasses.dataclass
@@ -91,6 +91,7 @@ class GBGPUCuda11xBackend(Cuda11xBackend, GBGPUBackend):
             xp=cupy,
         )
 
+
 class GBGPUCuda12xBackend(Cuda12xBackend, GBGPUBackend):
     """Implementation of CUDA 12.x backend"""
     _backend_name : str = "gbgpu_backend_cuda12x"
@@ -124,7 +125,41 @@ class GBGPUCuda12xBackend(Cuda12xBackend, GBGPUBackend):
         )
 
 
+class GBGPUCuda13xBackend(Cuda13xBackend, GBGPUBackend):
+    """Implementation of CUDA 13.x backend"""
+    _backend_name : str = "gbgpu_backend_cuda13x"
+    _name = "gbgpu_cuda13x"
+    
+    def __init__(self, *args, **kwargs):
+        Cuda13xBackend.__init__(self, *args, **kwargs)
+        GBGPUBackend.__init__(self, self.cuda13x_module_loader())
+        
+    @staticmethod
+    def cuda13x_module_loader():
+        try:
+            import gbgpu_backend_cuda13x.utils
+
+        except (ModuleNotFoundError, ImportError) as e:
+            raise BackendUnavailableException(
+                "'cuda13x' backend could not be imported."
+            ) from e
+
+        try:
+            import cupy
+        except (ModuleNotFoundError, ImportError) as e:
+            raise MissingDependencies(
+                "'cuda13x' backend requires cupy", pip_deps=["cupy-cuda13x"]
+            ) from e
+
+        return GBGPUBackendMethods(
+            get_ll=gbgpu_backend_cuda13x.utils.get_ll,
+            fill_global=gbgpu_backend_cuda13x.utils.fill_global,
+            xp=cupy,
+        )
+        
+        
 KNOWN_BACKENDS = {
+    "cuda13x": GBGPUCuda13xBackend,
     "cuda12x": GBGPUCuda12xBackend,
     "cuda11x": GBGPUCuda11xBackend,
     "cpu": GBGPUCpuBackend,


### PR DESCRIPTION
This pull request adds the cuda13xbackends to gbgpu. 
Important to note is that cuda13 is not necessarily supported for v100s (CUDA_ARCH "70") and older. 
Because the master branch specifically looks for ``native``, specific checks are not performed under the assumption that the correct gpu is used.
The following checks were performed and were passed:
- Does the package install without any problems. 
- Can the correct cuda backend be reached by ``import gbgpu`` + ``gbgpu.get_backend("gbgu_cuda13x")``