### PR TITLE
fix(cuda): rename CPU-path totals in gb_signal_het_make_reference_wrap

### DIFF
--- a/src/gbgpu/cutils/gb_tdi_on_the_fly.cu
+++ b/src/gbgpu/cutils/gb_tdi_on_the_fly.cu
@@ -3063,10 +3063,10 @@ void GBComputationGroup::gb_signal_het_make_reference_wrap(
     // (window width Nt, layer stride half_Nt), so the dense iDFT totals
     // O(2 * N_sparse_fd * Nt_active) per (d, c) instead of the previous
     // O(Nf_active * Nt * Nt_active) full sweep.
-    const size_t n_sparse_tot = (size_t) num_data * nchannels * Nf_active * N_sparse_t;
-    const size_t n_dense_tot  = (size_t) num_data * nchannels * Nf_active * Nt_active;
-    std::fill(c0_sparse_out, c0_sparse_out + n_sparse_tot, cmplx(0.0, 0.0));
-    std::fill(c0_dense_out,  c0_dense_out  + n_dense_tot,  cmplx(0.0, 0.0));
+    const size_t n_sparse_tot_cpu = (size_t) num_data * nchannels * Nf_active * N_sparse_t;
+    const size_t n_dense_tot_cpu  = (size_t) num_data * nchannels * Nf_active * Nt_active;
+    std::fill(c0_sparse_out, c0_sparse_out + n_sparse_tot_cpu, cmplx(0.0, 0.0));
+    std::fill(c0_dense_out,  c0_dense_out  + n_dense_tot_cpu,  cmplx(0.0, 0.0));
 
     std::vector<cmplx> fold_s(Nt_layer);
     std::vector<cmplx> fold_d(Nt);


### PR DESCRIPTION
The CUDA build of GBGPU currently fails on a redeclaration.

In `gb_signal_het_make_reference_wrap` (`src/gbgpu/cutils/gb_tdi_on_the_fly.cu`), `n_sparse_tot` / `n_dense_tot` are declared at L2977 inside `#ifdef __CUDACC__` and again at L3063 in the CPU path. The guard is `#ifdef ... return; #endif` with no `#else`, so under nvcc the CPU body is not excluded and both declarations land at function scope.

CPU-only builds never see this, which is why it goes unnoticed.

Fix suffixes the CPU-path locals with `_cpu`. No behaviour change on either backend.

Context: one of three patches needed to get the MBH GPU global fit running on ACCRE — https://github.com/lisa-analysis-tools/lisa-analysis-tools/issues/77

🤖 Generated with [Claude Code](https://claude.com/claude-code)